### PR TITLE
ZON-2930: Add separate facebook fields for article/gallery/link

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,10 +2,10 @@ zeit.campus changes
 ====================
 
 
-1.4.1 (unreleased)
+1.5.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- ZON-2930: Add separate facebook fields for article/gallery/link
 
 
 1.4.0 (2016-04-06)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='zeit.campus',
-    version='1.4.1.dev0',
+    version='1.5.0.dev0',
     author='Zeit Online',
     author_email='zon-backend@zeit.de',
     url='http://www.zeit.de/',
@@ -27,6 +27,7 @@ setup(
         'zeit.content.gallery',
         'zeit.content.infobox',
         'zeit.content.link',
+        'zeit.push>=1.13.0.dev0',
         'zope.component',
         'zope.interface',
         'zope.schema',

--- a/src/zeit/campus/browser/article.py
+++ b/src/zeit/campus/browser/article.py
@@ -1,5 +1,6 @@
 from zeit.cms.i18n import MessageFactory as _
 from zeit.content.article.edit.browser.form import FormFields
+import zeit.campus.browser.social
 import zeit.cms.browser.interfaces
 import zeit.edit.browser.form
 import zope.interface
@@ -30,3 +31,8 @@ class StudyCourse(zeit.edit.browser.form.InlineForm):
     undo_description = _('edit study course')
     form_fields = FormFields(
         zeit.campus.interfaces.IStudyCourse).select('course')
+
+
+class Social(zeit.content.article.edit.browser.social.Social,
+             zeit.campus.browser.social.SocialBase):
+    pass

--- a/src/zeit/campus/browser/configure.zcml
+++ b/src/zeit/campus/browser/configure.zcml
@@ -43,6 +43,14 @@
     permission="zope.View"
     />
 
+  <browser:page
+    for="..interfaces.IZCOArticle"
+    layer="zeit.cms.browser.interfaces.ICMSLayer"
+    name="edit.form.social"
+    class=".article.Social"
+    permission="zope.View"
+    />
+
   <!-- infobox -->
 
   <browser:page
@@ -68,6 +76,58 @@
     for="..interfaces.IZCOInfobox"
     layer="zeit.cms.browser.interfaces.ICMSLayer"
     class=".infobox.Display"
+    permission="zope.View"
+    />
+
+  <!-- link -->
+
+  <browser:page
+    for="..interfaces.IZCOFolder"
+    layer="zeit.cms.browser.interfaces.ICMSLayer"
+    class=".link.Add"
+    name="zeit.content.link.Add"
+    permission="zeit.AddContent"
+    menu="zeit-add-menu" title="Link"
+    />
+
+  <browser:page
+    name="edit.html"
+    for="..interfaces.IZCOLink"
+    class=".link.Edit"
+    permission="zeit.EditContent"
+    menu="zeit-context-views" title="Edit metadata"
+    />
+
+  <browser:page
+    name="view.html"
+    for="..interfaces.IZCOLink"
+    class=".link.Display"
+    permission="zope.View"
+    />
+
+  <!-- gallery -->
+
+  <browser:page
+    for="..interfaces.IZCOFolder"
+    layer="zeit.cms.browser.interfaces.ICMSLayer"
+    class=".gallery.Add"
+    name="zeit.content.gallery.Add"
+    permission="zeit.AddContent"
+    menu="zeit-add-menu" title="Gallery"
+    />
+
+  <browser:page
+    name="edit.html"
+    for="..interfaces.IZCOGallery"
+    class=".gallery.Edit"
+    permission="zeit.EditContent"
+    menu="zeit-context-views" title="Edit metadata"
+    />
+
+  <browser:page
+    name="view.html"
+    for="..interfaces.IZCOGallery"
+    class=".gallery.Display"
     permission="zope.View"
     />
 

--- a/src/zeit/campus/browser/gallery.py
+++ b/src/zeit/campus/browser/gallery.py
@@ -1,0 +1,29 @@
+# XXX 100% copy&paste from zeit.magazin.browser.social
+import zeit.content.gallery.browser.form
+import zeit.campus.browser.social
+
+
+base = zeit.content.gallery.browser.form.GalleryFormBase
+field_groups = (
+    base.field_groups[:4]
+    + (zeit.campus.browser.social.SocialBase.social_fields,)
+    + base.field_groups[5:]
+)
+
+
+class Add(zeit.campus.browser.social.SocialBase,
+          zeit.content.gallery.browser.form.AddGallery):
+
+    field_groups = field_groups
+
+
+class Edit(zeit.campus.browser.social.SocialBase,
+           zeit.content.gallery.browser.form.EditGallery):
+
+    field_groups = field_groups
+
+
+class Display(zeit.campus.browser.social.SocialBase,
+              zeit.content.gallery.browser.form.DisplayGallery):
+
+    field_groups = field_groups

--- a/src/zeit/campus/browser/link.py
+++ b/src/zeit/campus/browser/link.py
@@ -1,0 +1,29 @@
+# XXX 100% copy&paste from zeit.magazin.browser.social
+import zeit.content.link.browser.form
+import zeit.campus.browser.social
+
+
+base = zeit.content.link.browser.form.Base
+field_groups = (
+    base.field_groups[:4]
+    + (zeit.campus.browser.social.SocialBase.social_fields,)
+    + base.field_groups[5:]
+)
+
+
+class Add(zeit.campus.browser.social.SocialBase,
+          zeit.content.link.browser.form.Add):
+
+    field_groups = field_groups
+
+
+class Edit(zeit.campus.browser.social.SocialBase,
+           zeit.content.link.browser.form.Edit):
+
+    field_groups = field_groups
+
+
+class Display(zeit.campus.browser.social.SocialBase,
+              zeit.content.link.browser.form.Display):
+
+    field_groups = field_groups

--- a/src/zeit/campus/browser/social.py
+++ b/src/zeit/campus/browser/social.py
@@ -1,0 +1,35 @@
+# XXX 100% copy&paste from zeit.magazin.browser.social
+import copy
+import zeit.push.browser.form
+import zeit.push.interfaces
+
+
+class SocialBase(zeit.push.browser.form.SocialBase):
+
+    campus_fields = ('facebook_campus_text', 'facebook_campus_enabled')
+
+    social_fields = copy.copy(zeit.push.browser.form.SocialBase.social_fields)
+    social_fields.fields = (
+        social_fields.fields[:2]
+        + campus_fields
+        + social_fields.fields[2:]
+    )
+
+    def __init__(self, *args, **kw):
+        super(SocialBase, self).__init__(*args, **kw)
+        # Insert campus_fields at the wanted position
+        self.form_fields = self.form_fields.omit(*self.social_fields.fields)
+        self.form_fields += self.social_form_fields.select(
+            *self.social_fields.fields)
+
+    @property
+    def social_form_fields(self):
+        return (
+            super(SocialBase, self).social_form_fields
+            + self.FormFieldsFactory(zeit.push.interfaces.IAccountData).select(
+                *self.campus_fields))
+
+    def setUpWidgets(self, *args, **kw):
+        super(SocialBase, self).setUpWidgets(*args, **kw)
+        if self.request.form.get('%s.facebook_campus_enabled' % self.prefix):
+            self._set_widget_required('facebook_campus_text')

--- a/src/zeit/campus/browser/tests/test_gallery.py
+++ b/src/zeit/campus/browser/tests/test_gallery.py
@@ -1,0 +1,35 @@
+import gocept.testing.assertion
+import zeit.cms.testing
+import zeit.campus.testing
+
+
+class ZCOGalleryCRUD(zeit.cms.testing.BrowserTestCase,
+                     gocept.testing.assertion.String):
+
+    layer = zeit.campus.testing.LAYER
+
+    def test_zco_gallery_has_facebook_campus_fields(self):
+        b = self.browser
+        b.open('http://localhost/++skin++vivi/repository/campus')
+        menu = b.getControl(name='add_menu')
+        menu.displayValue = ['Gallery']
+        b.open(menu.value[0])
+
+        b.getControl('File name').value = 'gallery'
+        b.getControl('Title').value = 'title'
+        b.getControl('Ressort', index=0).displayValue = ['Leben']
+        b.getControl('Teaser title').value = 'teaser'
+        b.getControl(name="form.image_folder").value = (
+            'http://xml.zeit.de/online/2007/01')
+        b.getControl(name='form.authors.0.').value = 'Author'
+
+        b.getControl('Facebook Campus Text').value = 'mycampus'
+        b.getControl(name='form.actions.add').click()
+
+        self.assertEndsWith('@@overview.html', b.url)
+        b.getLink('Edit metadata').click()
+        self.assertEqual(
+            'mycampus', b.getControl('Facebook Campus Text').value)
+
+        b.getLink('Checkin').click()
+        self.assertEllipsis('...mycampus...', b.contents)

--- a/src/zeit/campus/browser/tests/test_link.py
+++ b/src/zeit/campus/browser/tests/test_link.py
@@ -1,0 +1,32 @@
+import gocept.testing.assertion
+import zeit.cms.testing
+import zeit.campus.testing
+
+
+class ZCOLinkCRUD(zeit.cms.testing.BrowserTestCase,
+                  gocept.testing.assertion.String):
+
+    layer = zeit.campus.testing.LAYER
+
+    def test_zmo_link_has_facebook_campus_fields(self):
+        b = self.browser
+        b.open('http://localhost/++skin++vivi/repository/campus')
+        menu = b.getControl(name='add_menu')
+        menu.displayValue = ['Link']
+        b.open(menu.value[0])
+
+        b.getControl('File name').value = 'link'
+        b.getControl('Title').value = 'title'
+        b.getControl('Ressort', index=0).displayValue = ['Leben']
+        b.getControl('Teaser title').value = 'teaser'
+        b.getControl('Link address').value = 'http://example.com'
+
+        b.getControl('Facebook Campus Text').value = 'mycampus'
+        b.getControl(name='form.actions.add').click()
+
+        self.assertEndsWith('@@edit.html', b.url)
+        self.assertEqual(
+            'mycampus', b.getControl('Facebook Campus Text').value)
+
+        b.getLink('Checkin').click()
+        self.assertEllipsis('...mycampus...', b.contents)

--- a/src/zeit/campus/ftesting.zcml
+++ b/src/zeit/campus/ftesting.zcml
@@ -13,6 +13,8 @@
   <include package="zeit.content.infobox" file="ftesting.zcml"/>
   <include package="zeit.content.link" file="ftesting.zcml"/>
 
+  <include package="zeit.push"/>
+
   <include package="zeit.campus" />
   <include package="zeit.campus.browser" />
 

--- a/src/zeit/campus/testing.py
+++ b/src/zeit/campus/testing.py
@@ -6,6 +6,9 @@ import plone.testing
 import zeit.cms.repository.interfaces
 import zeit.cms.testing
 import zeit.content.article.testing
+import zeit.content.gallery.testing
+import zeit.content.link.testing
+import zeit.push
 import zope.component
 import zope.interface
 
@@ -21,8 +24,11 @@ ZCML_LAYER = zeit.cms.testing.ZCMLLayer(
     'ftesting.zcml', product_config=(
         product_config
         + zeit.cms.testing.cms_product_config
+        + zeit.push.product_config
         + zeit.content.article.testing.product_config
-        + zeit.content.cp.testing.product_config))
+        + zeit.content.cp.testing.product_config
+        + zeit.content.gallery.testing.product_config
+        + zeit.content.link.testing.product_config))
 
 
 class Layer(plone.testing.Layer):


### PR DESCRIPTION
Needs https://github.com/ZeitOnline/zeit.push/pull/1

This is basically copy&paste of zeit.magazin commit:ddda7ce;
not sure if we're missing an abstraction somewhere.
